### PR TITLE
Add automatic username and repository name setup

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,17 +12,17 @@
 
 # ....Repository wide code owner...................................................................
 # These owners will be the default owners for everything in the repo.
-#*       @RedLeader962
+*       @TNP_GIT_USER_NAME_PLACEHOLDER
 
 # ....Core directories and files...................................................................
-#/src/ @RedLeader962
-#/tests/ @RedLeader962
-#/README.md @RedLeader962
-#/.env* @RedLeader962
+#/src/ @TNP_GIT_USER_NAME_PLACEHOLDER
+#/tests/ @TNP_GIT_USER_NAME_PLACEHOLDER
+#/README.md @TNP_GIT_USER_NAME_PLACEHOLDER
+#/.env* @TNP_GIT_USER_NAME_PLACEHOLDER
 
 # ....DevOps related...............................................................................
-#/.github/ @RedLeader962
-#/build_system/ @RedLeader962
-#/.gitignore @RedLeader962
-#/.gitmodules @RedLeader962
-#/.dockerignore @RedLeader962
+#/.github/ @TNP_GIT_USER_NAME_PLACEHOLDER
+#/build_system/ @TNP_GIT_USER_NAME_PLACEHOLDER
+#/.gitignore @TNP_GIT_USER_NAME_PLACEHOLDER
+#/.gitmodules @TNP_GIT_USER_NAME_PLACEHOLDER
+#/.dockerignore @TNP_GIT_USER_NAME_PLACEHOLDER

--- a/.run/open-a-terminal-in-ubuntu-container.run.xml
+++ b/.run/open-a-terminal-in-ubuntu-container.run.xml
@@ -1,16 +1,16 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="runBatsTestsAll" type="ShConfigurationType" folderName="[TNP] A | bats tests" focusToolWindowBeforeRun="true">
-    <option name="SCRIPT_TEXT" value="" />
+  <configuration default="false" name="open-a-terminal-in-ubuntu-container" type="ShConfigurationType" folderName="[TNP] B | docker utilities">
+    <option name="SCRIPT_TEXT" value="docker run --privileged --name IamUbuntu-focal -it --rm ubuntu:20.04 bash" />
     <option name="INDEPENDENT_SCRIPT_PATH" value="true" />
-    <option name="SCRIPT_PATH" value="$PROJECT_DIR$/tests/run_bats_core_test_in_n2st.tnp.bash" />
-    <option name="SCRIPT_OPTIONS" value="tests/tests_bats" />
+    <option name="SCRIPT_PATH" value="" />
+    <option name="SCRIPT_OPTIONS" value="" />
     <option name="INDEPENDENT_SCRIPT_WORKING_DIRECTORY" value="true" />
     <option name="SCRIPT_WORKING_DIRECTORY" value="$PROJECT_DIR$" />
     <option name="INDEPENDENT_INTERPRETER_PATH" value="true" />
     <option name="INTERPRETER_PATH" value="/bin/zsh" />
     <option name="INTERPRETER_OPTIONS" value="" />
     <option name="EXECUTE_IN_TERMINAL" value="true" />
-    <option name="EXECUTE_SCRIPT_FILE" value="true" />
+    <option name="EXECUTE_SCRIPT_FILE" value="false" />
     <envs />
     <method v="2" />
   </configuration>

--- a/.run/run-Bats-Tests-All.run.xml
+++ b/.run/run-Bats-Tests-All.run.xml
@@ -1,16 +1,16 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="openATerminalInUbuntuContainer" type="ShConfigurationType" folderName="[TNP] B | docker utilities">
-    <option name="SCRIPT_TEXT" value="docker run --privileged --name IamUbuntu-focal -it --rm ubuntu:20.04 bash" />
+  <configuration default="false" name="run-Bats-Tests-All" type="ShConfigurationType" folderName="[TNP] A | bats tests" focusToolWindowBeforeRun="true">
+    <option name="SCRIPT_TEXT" value="" />
     <option name="INDEPENDENT_SCRIPT_PATH" value="true" />
-    <option name="SCRIPT_PATH" value="" />
-    <option name="SCRIPT_OPTIONS" value="" />
+    <option name="SCRIPT_PATH" value="$PROJECT_DIR$/tests/run_bats_core_test_in_n2st.tnp.bash" />
+    <option name="SCRIPT_OPTIONS" value="tests/tests_bats" />
     <option name="INDEPENDENT_SCRIPT_WORKING_DIRECTORY" value="true" />
     <option name="SCRIPT_WORKING_DIRECTORY" value="$PROJECT_DIR$" />
     <option name="INDEPENDENT_INTERPRETER_PATH" value="true" />
     <option name="INTERPRETER_PATH" value="/bin/zsh" />
     <option name="INTERPRETER_OPTIONS" value="" />
     <option name="EXECUTE_IN_TERMINAL" value="true" />
-    <option name="EXECUTE_SCRIPT_FILE" value="false" />
+    <option name="EXECUTE_SCRIPT_FILE" value="true" />
     <envs />
     <method v="2" />
   </configuration>

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Maintainer <a href="https://redleader962.github.io">Luc Coupal</a>
 # How to use this template repository
 
 - [ ] [Step 1 › Generate the new repository](#step-1--generate-the-new-repository)
-- [ ] [Step 2 › Execute `initialize_norlab_project_template.bash` (Support Ubuntu and Mac OsX)](#step-2--execute-initialize_norlab_project_templatebash)
+- [ ] [Step 2 › Execute initialization script](#step-2--execute-initialization-script)
 - [ ] [Step 3 › Make it your own](#step-3--make-it-your-own)
 - [ ] [Step 4 › Configure the _GitHub_ repository settings](#step-4--configure-the-github-repository-settings)
 - [ ] [Step 5 › Release automation: enable semantic versioning tools](#step-5--enable-release-automation-tools-semantic-versioning)
@@ -86,9 +86,14 @@ Maintainer <a href="https://redleader962.github.io">Luc Coupal</a>
 $ git clone --recurse-submodule https://github.com/<your-git-repository-url>
 ```
 
-## Step 2 › Execute `initialize_norlab_project_template.bash`
+## Step 2 › Execute initialization script
+(Support Unix system: Ubuntu and Mac OsX)
 
-(Support Ubuntu and Mac OsX)
+```shell
+# From repository root, execute the following line
+$ bash initialize_norlab_project_template.bash
+# Follow the instruction on the console
+```
 
 It will execute the following steps:
 
@@ -107,6 +112,43 @@ It will execute the following steps:
        to `README.md` and delete the other one
    3. customize url references 
 4. Reset the content of `CHANGELOG.md`
+
+When the script execution is done, you will end up with the following repository structure:
+```markdown
+my_new_cool_repo
+├── README.md
+├── CHANGELOG.md
+├── commit_msg_reference.md
+├── version.txt
+├── .env.my_new_cool_repo
+├── data
+│   └── README.md
+├── src
+│   ├── README.md
+│   └── dummy.bash
+├── tests
+│   ├── README.md
+│   ├── run_bats_core_test_in_n2st.bash (optional)
+│   └── tests_bats (optional)
+├── utilities
+│   ├── norlab-build-system (optional)
+│   └── norlab-shell-script-tools (optional)
+├── visual
+│   └── ...
+├── .github
+│   ├── CODEOWNERS
+│   ├── pull_request_template.md
+│   └── workflows
+│       └── semantic_release.yml (optional)
+├── .gitignore
+├── .gitmodules
+├── .releaserc.json (optional)
+├── .run
+│   ├── openATerminalInUbuntuContainer.run.xml
+│   └── runBatsTestsAll.run.xml (optional)
+├── NORLAB_PROJECT_TEMPLATE_INSTRUCTIONS.md (to delete when done)
+└── initialize_norlab_project_template.bash (to delete when done)
+```
 
 ## Step 3 › Make it your own
 

--- a/README.norlab_template.md
+++ b/README.norlab_template.md
@@ -15,7 +15,7 @@
 
 [//]: # ( ==== Title ================================================= ) 
 [//]: # (TODO: change the title)
-# _NorLab Project Template_
+# _TNP_PROJECT_NAME_PLACEHOLDER_
 
 [//]: # ( ==== Hyperlink ============================================= ) 
 <sup>
@@ -62,7 +62,7 @@ fermentum.
 [//]: # ( ==== Maintainer ============================================ ) 
 [//]: # (TODO: Change the maintainer name)
 <sub>
-Maintainer <a href="https://redleader962.github.io">Luc Coupal</a>
+Maintainer <a href="https://github.com/TNP_GIT_USER_NAME_PLACEHOLDER">TNP_GIT_USER_NAME_PLACEHOLDER</a>
 </sub>
 
 <br>

--- a/README.vaul_template.md
+++ b/README.vaul_template.md
@@ -11,7 +11,7 @@
 
 [//]: # ( ==== Title ================================================= ) 
 [//]: # (TODO: change the title)
-# _VAUL › Project Template_
+# _TNP_PROJECT_NAME_PLACEHOLDER_
 
 
 [//]: # ( ==== Hyperlink ============================================= )
@@ -59,7 +59,7 @@ fermentum.
 [//]: # ( ==== Maintainer ============================================ ) 
 [//]: # (TODO: Change the maintainer name)
 <sub>
-Maintainer <a href="https://redleader962.github.io">Luc Coupal</a>
+Maintainer <a href="https://github.com/TNP_GIT_USER_NAME_PLACEHOLDER">TNP_GIT_USER_NAME_PLACEHOLDER</a>
 </sub>
 
 <br>

--- a/initialize_norlab_project_template.bash
+++ b/initialize_norlab_project_template.bash
@@ -164,7 +164,7 @@ function tnp::install_norlab_project_template(){
     echo
     unset INPUT
     read -r -a INPUT
-#    echo "INPUT=$INPUT" # User input feedback
+    # echo "INPUT=$INPUT" # User input feedback
     echo
 
     # Capitalise new prefix
@@ -180,10 +180,10 @@ function tnp::install_norlab_project_template(){
     mv .env.template-norlab-project.template ".env.${NEW_PROJECT_GIT_NAME}"
 
 
-    n2st::seek_and_modify_string_in_file "folderName=\"\[TNP\]" "folderName=\"\[${ENV_PREFIX}\]" .run/openATerminalInUbuntuContainer.run.xml
-    n2st::seek_and_modify_string_in_file "folderName=\"\[TNP\]" "folderName=\"\[${ENV_PREFIX}\]" .run/runBatsTestsAll.run.xml
+    n2st::seek_and_modify_string_in_file "folderName=\"\[TNP\]" "folderName=\"\[${ENV_PREFIX}\]" .run/open-a-terminal-in-ubuntu-container.run.xml
+    n2st::seek_and_modify_string_in_file "folderName=\"\[TNP\]" "folderName=\"\[${ENV_PREFIX}\]" .run/run-Bats-Tests-All.run.xml
 
-    n2st::seek_and_modify_string_in_file "tests/run_bats_core_test_in_n2st.tnp.bash" "tests/run_bats_core_test_in_n2st.bash" .run/runBatsTestsAll.run.xml
+    n2st::seek_and_modify_string_in_file "tests/run_bats_core_test_in_n2st.tnp.bash" "tests/run_bats_core_test_in_n2st.bash" .run/run-Bats-Tests-All.run.xml
 
     if [[ ${INSTALL_N2ST} == true ]]; then
       n2st::seek_and_modify_string_in_file "function n2st::" "function ${FCT_PREFIX}::" src/dummy.bash
@@ -193,7 +193,19 @@ function tnp::install_norlab_project_template(){
 
   }
 
+  # ....Update CODEOWNER file......................................................................
+  GIT_USER_NAME="$(git config user.name)"
+  echo ">>>> ${GIT_USER_NAME}"
+
+  {
+    cd "${TNP_ROOT}/.github" || exit 1
+    n2st::seek_and_modify_string_in_file "TNP_GIT_USER_NAME_PLACEHOLDER" "${GIT_USER_NAME:-'TODO-CHANGE-GIT-NAME'}" CODEOWNERS
+  }
+
   # ....Set main readme file.......................................................................
+  PROJECT_GIT_REMOTE_URL="$( git remote get-url origin )"
+  PROJECT_GIT_NAME="$( basename ${PROJECT_GIT_REMOTE_URL} .git )"
+
   {
     n2st::print_msg_awaiting_input "Which readme file you want to use? NorLab (Default) or VAUL"
     echo
@@ -230,7 +242,12 @@ function tnp::install_norlab_project_template(){
 
     fi
 
+    n2st::seek_and_modify_string_in_file "https://github.com/TNP_GIT_USER_NAME_PLACEHOLDER\">TNP_GIT_USER_NAME_PLACEHOLDER" "https://github.com/${GIT_USER_NAME:-'TODO-CHANGE-MAINTAINER'}\">${GIT_USER_NAME:-'TODO-CHANGE-MAINTAINER'}*" README.md
+    n2st::seek_and_modify_string_in_file "TNP_PROJECT_NAME_PLACEHOLDER" "${NEW_PROJECT_GIT_NAME}" README.md
+
   }
+
+
 
   # ....Commit project configuration steps.........................................................
   {
@@ -253,14 +270,14 @@ function tnp::install_norlab_project_template(){
       rm -R src/dummy.bash
       rm -R tests/tests_bats
       rm -R tests/run_bats_core_test_in_n2st.template.bash
-      rm -R ".run/runBatsTestsAll.run.xml"
+      rm -R ".run/run-Bats-Tests-All.run.xml"
 
       n2st::print_msg "Commit N2ST lib deletion"
       git add src/dummy.bash
       git add ".env.${NEW_PROJECT_GIT_NAME}"
       git add tests/tests_bats
       git add tests/run_bats_core_test_in_n2st.template.bash
-      git add ".run/runBatsTestsAll.run.xml"
+      git add ".run/run-Bats-Tests-All.run.xml"
       git commit -m 'build: Deleted norlab-shell-script-tools submodule from repository'
 
     fi

--- a/tests/tests_bats/bats_testing_tools/norlab_project_template_helper_functions.bash
+++ b/tests/tests_bats/bats_testing_tools/norlab_project_template_helper_functions.bash
@@ -63,6 +63,8 @@ function norlab_project_template_directory_reset_check() {
     assert_file_contains .env.template-norlab-project.template "^PLACEHOLDER_PATH.*"
     assert_file_contains .env.template-norlab-project.template "^PLACEHOLDER_SRC_NAME.*"
     assert_file_contains .env.template-norlab-project.template "^PROJECT_PROMPT_NAME='Norlab-Project-Template'"
+
+
 }
 
 function check_NBS_is_installed() {

--- a/tests/tests_bats/test_initialize_norlab_project_template.bats
+++ b/tests/tests_bats/test_initialize_norlab_project_template.bats
@@ -210,6 +210,8 @@ teardown() {
   source .env.template-norlab-project
   set +o allexport
 
+  # ....Check CODEOWNER file.......................................................................
+  assert_file_not_contains .github/CODEOWNERS "TNP_GIT_USER_NAME_PLACEHOLDER"
 }
 
 @test "Validate git add steps and gitignore configuration › expect pass" {
@@ -280,14 +282,14 @@ teardown() {
   assert_file_contains tests/run_bats_core_test_in_n2st.bash "MY_PROJECT_"
 
   # ....Modify run config related files............................................................
-  assert_file_not_contains .run/openATerminalInUbuntuContainer.run.xml "folderName=\"\[TNP\]"
-  assert_file_contains .run/openATerminalInUbuntuContainer.run.xml "folderName=\"\[MY_PROJECT\]"
+  assert_file_not_contains .run/open-a-terminal-in-ubuntu-container.run.xml "folderName=\"\[TNP\]"
+  assert_file_contains .run/open-a-terminal-in-ubuntu-container.run.xml "folderName=\"\[MY_PROJECT\]"
 
-  assert_file_not_contains .run/runBatsTestsAll.run.xml "folderName=\"\[TNP\]"
-  assert_file_contains .run/runBatsTestsAll.run.xml "folderName=\"\[MY_PROJECT\]"
+  assert_file_not_contains .run/run-Bats-Tests-All.run.xml "folderName=\"\[TNP\]"
+  assert_file_contains .run/run-Bats-Tests-All.run.xml "folderName=\"\[MY_PROJECT\]"
 
-  assert_file_not_contains .run/runBatsTestsAll.run.xml "tests/run_bats_core_test_in_n2st.tnp.bash"
-  assert_file_contains .run/runBatsTestsAll.run.xml "tests/run_bats_core_test_in_n2st.bash"
+  assert_file_not_contains .run/run-Bats-Tests-All.run.xml "tests/run_bats_core_test_in_n2st.tnp.bash"
+  assert_file_contains .run/run-Bats-Tests-All.run.xml "tests/run_bats_core_test_in_n2st.bash"
 
   # ....Check Semantic-Release install.............................................................
   check_semantic_release_is_installed
@@ -461,6 +463,9 @@ teardown() {
   assert_file_contains README.md "img.shields.io/github/v/release/norlab-ulaval/template-norlab-project"
   assert_file_contains README.md "norlab-ulaval/template-norlab-project.git"
 
+  assert_file_not_contains README.md "TNP_GIT_USER_NAME_PLACEHOLDER"
+  assert_file_not_contains README.md "TNP_PROJECT_NAME_PLACEHOLDER"
+
 }
 
 @test "Case install VAUL readme  › expect pass" {
@@ -493,6 +498,9 @@ teardown() {
 
   assert_file_contains README.md "img.shields.io/github/v/release/vaul-ulaval/template-norlab-project"
   assert_file_contains README.md "vaul-ulaval/template-norlab-project.git"
+
+  assert_file_not_contains README.md "TNP_GIT_USER_NAME_PLACEHOLDER"
+  assert_file_not_contains README.md "TNP_PROJECT_NAME_PLACEHOLDER"
 
 }
 


### PR DESCRIPTION
# Description
This feature introduces automatic setup of the git user name and repository name in configuration files. Key changes include:

- Standardized naming conventions for run configuration files.
- Updated `CODEOWNERS` and `README.md` to automatically fetch the git config user name and repository name.
- Enhanced maintainability through improved comments and script restructuring.

# Checklist:

### Code related
- [ ] I have made corresponding changes to the documentation (i.e.: function/class, script header, README.md)
- [ ] I have commented hard-to-understand code 
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes (Check `tests/README.md` for local testing procedure) 
- [x] My commit messages follow the [conventional commits](https://www.conventionalcommits.org) specification. See `commit_msg_reference.md` in the repository root for details

### PR creation related 
- [x] My pull request `base ref` branch is set to the `dev` branch (the _build-system_ won't be triggered otherwise) 
- [x] My pull request branch is up-to-date with the `dev` branch (the _build-system_ will reject it otherwise)

 ## Note for repository admins
 ### Release PR related
- Only repository admins have the privilege to `push/merge` on the default branch (ie: `main`) and the `release` branch.
- Keep PR in `draft` mode until all the release reviewers are ready to push the release. 
- Once a PR from `release` -> `main` branch is created (not in draft mode), it triggers the _build-system_ test
- On merge to the `main` branch, it triggers the _semantic-release automation_