### PR TITLE
GitHub Branch Protection Improvements and Refactoring 

### DIFF
--- a/.junie/scratch.md
+++ b/.junie/scratch.md
@@ -1,6 +1,18 @@
 
 # Scratch
 
+Improve `configure_github_branch_protection.bash`: 
+- remove `gbp::status_check_configuration` function usage everywhere;
+- delete `gbp::status_check_configuration` function;
+- update tests accordingly.
+Follow guidelines at `.junie/guidelines.md`.
+Check if it introduce any breaking change in the code base by running both unit-tests and integration tests.
+Propose source code change if relevant.
+Execute all unit-tests and all integration tests before submitting.
+
+
+---
+
 Don't assume the default branch is `main`.
 The default branch is arbitrary and is set on GitHub.
 Review your proposed solution accordingly.

--- a/.junie/scratch.md
+++ b/.junie/scratch.md
@@ -10,7 +10,6 @@ Check if it introduce any breaking change in the code base by running both unit-
 Propose source code change if relevant.
 Execute all unit-tests and all integration tests before submitting.
 
-
 ---
 
 Don't assume the default branch is `main`.

--- a/configure_github_branch_protection.bash
+++ b/configure_github_branch_protection.bash
@@ -202,7 +202,7 @@ function gbp::configure_branch_protection() {
 {
   "required_status_checks": {
     "strict": true,
-    "contexts": [${GBP_CI_CHECKS}]
+    "contexts": []
   },
   "enforce_admins": false,
   "required_pull_request_reviews": {
@@ -239,18 +239,6 @@ EOF
     fi
 }
 
-function gbp::status_check_configuration() {
-    local user_input
-
-    n2st::print_msg_awaiting_input "Configure CI status checks? (y/N)"
-    read -n 1 -r user_input
-
-    if [[ "${user_input}" == "y" || "${user_input}" == "Y" ]]; then
-        n2st::print_msg_awaiting_input "Enter CI check names (comma-separated, e.g., 'ci/tests,ci/build'):"
-        read -r ci_checks
-        echo "${ci_checks}"
-    fi
-}
 
 function gbp::update_releaserc_json() {
     local release_branch="$1"
@@ -406,14 +394,6 @@ function gbp::main() {
     if [[ "$release_branch_specified" == "false" ]]; then
         release_branch="${REPO_DEFAULT_BRANCH:-main}"
         n2st::print_msg "Using repository default branch as release branch: $release_branch"
-    fi
-
-    if [[ "$dry_run" == "false" ]]; then
-        # Interactive configuration if not dry run
-        GBP_CI_CHECKS=$( gbp::status_check_configuration )
-        export GBP_CI_CHECKS
-    else
-        n2st::print_msg "DRY RUN: Would set GBP_CI_CHECKS env var"
     fi
 
     # Update .releaserc.json if using non-default release branch name

--- a/configure_github_branch_protection.bash
+++ b/configure_github_branch_protection.bash
@@ -37,6 +37,7 @@ source "${N2ST_PATH:?err}/import_norlab_shell_script_tools_lib.bash"
 # ====Functions====================================================================================
 function gbp::validate_prerequisites() {
     local repo_url
+    n2st::print_msg "Validate pre-prerequisites"
 
     # Check if gh CLI is installed
     if ! command -v jq &> /dev/null; then
@@ -72,12 +73,13 @@ function gbp::validate_prerequisites() {
         return 1
     fi
 
+    n2st::print_msg_done "Validate pre-prerequisites"
     return 0
 }
 
 function gbp::get_repository_info() {
     local repo_info
-    repo_info=$(gh repo view --json owner,name,defaultBranchRef)
+    repo_info=$(gh repo view --json "owner,name,defaultBranchRef")
 
     REPO_OWNER=$(echo "$repo_info" | jq -r '.owner.login')
     REPO_NAME=$(echo "$repo_info" | jq -r '.name')

--- a/configure_github_branch_protection.bash
+++ b/configure_github_branch_protection.bash
@@ -97,7 +97,7 @@ function gbp::rename_branch_if_needed() {
     local default_branch="${REPO_DEFAULT_BRANCH:-main}"
 
     # Only rename for non-default release branch names
-    if [[ "$target_branch" == "$default_branch" ]]; then
+    if [[ "${target_branch}" == "${default_branch}" ]]; then
         return 0
     fi
 
@@ -105,55 +105,64 @@ function gbp::rename_branch_if_needed() {
     local default_exists=false
     local target_exists=false
 
-    if git show-ref --verify --quiet "refs/heads/$default_branch" || \
-       git show-ref --verify --quiet "refs/remotes/origin/$default_branch"; then
+    if git show-ref --verify --quiet "refs/heads/${default_branch}" || \
+       git show-ref --verify --quiet "refs/remotes/origin/${default_branch}"; then
         default_exists=true
     fi
 
-    if git show-ref --verify --quiet "refs/heads/$target_branch" || \
-       git show-ref --verify --quiet "refs/remotes/origin/$target_branch"; then
+    if git show-ref --verify --quiet "refs/heads/${target_branch}" || \
+       git show-ref --verify --quiet "refs/remotes/origin/${target_branch}"; then
         target_exists=true
     fi
 
     # Only rename if default exists and target doesn't exist
     if [[ "$default_exists" == "true" && "$target_exists" == "false" ]]; then
         if [[ "$dry_run" == "true" ]]; then
-            n2st::print_msg "DRY RUN: Would rename branch '$default_branch' to '$target_branch'"
+            n2st::print_msg "DRY RUN: Would rename branch '${default_branch}' to '${target_branch}'"
             return 0
         fi
 
-        n2st::print_msg "Renaming branch '$default_branch' to '$target_branch'..."
+        n2st::print_msg "Renaming branch '${default_branch}' to '${target_branch}'..."
 
         # Get current branch to restore later
         local current_branch
         current_branch=$(git branch --show-current)
 
         # Checkout the default branch if not already on it
-        if [[ "$current_branch" != "$default_branch" ]]; then
-            if ! git checkout "$default_branch"; then
-                n2st::print_msg_error "Failed to checkout '$default_branch' for renaming"
+        if [[ "$current_branch" != "${default_branch}" ]]; then
+            if ! git checkout "${default_branch}"; then
+                n2st::print_msg_error "Failed to checkout '${default_branch}' for renaming"
                 return 1
             fi
         fi
 
         # Rename the branch locally
-        if git branch -m "$target_branch"; then
+        if git branch -m "${target_branch}"; then
+
             # Push the new branch and delete the old one from remote
-            if git push -u origin "$target_branch" && git push origin --delete "$default_branch"; then
-                n2st::print_msg_done "Branch '$default_branch' renamed to '$target_branch'"
+            if git push -u origin "${target_branch}"; then
+                n2st::print_msg_done "Branch '${default_branch}' renamed to '${target_branch}'"
+
                 # Update the default branch on GitHub if we're renaming the default
                 if [[ "$dry_run" == "false" ]]; then
-                    gh repo edit --default-branch "$target_branch" 2>/dev/null || true
+                    gh repo edit --default-branch "${target_branch}" 2>/dev/null || true
                 fi
+
+                # Delete old remote
+                git push origin --delete "${default_branch}"
+
+                # Remove reference to deleted remote branch
+                git fetch --prune
+
                 return 0
             else
                 n2st::print_msg_error "Failed to update remote references for renamed branch"
                 # Try to restore the original branch name
-                git branch -m "$default_branch" 2>/dev/null || true
+                git branch -m "${current_branch}" 2>/dev/null || true
                 return 1
             fi
         else
-            n2st::print_msg_error "Failed to rename branch '$default_branch' to '$target_branch'"
+            n2st::print_msg_error "Failed to rename branch '${default_branch}' to '${target_branch}'"
             return 1
         fi
     fi
@@ -166,26 +175,26 @@ function gbp::create_branch_if_not_exists() {
     local dry_run="$2"
 
     # Check if branch exists locally or remotely
-    if git show-ref --verify --quiet "refs/heads/$branch_name" || \
-      git show-ref --verify --quiet "refs/remotes/origin/$branch_name"; then
-        n2st::print_msg "Branch '$branch_name' already exists"
+    if git show-ref --verify --quiet "refs/heads/${branch_name}" || \
+      git show-ref --verify --quiet "refs/remotes/origin/${branch_name}"; then
+        n2st::print_msg "Branch '${branch_name}' already exists"
         return 0
     fi
 
     if [[ "$dry_run" == "true" ]]; then
-        n2st::print_msg "DRY RUN: Would create branch '$branch_name'"
+        n2st::print_msg "DRY RUN: Would create branch '${branch_name}'"
         return 0
     fi
 
-    n2st::print_msg "Creating branch '$branch_name'..."
+    n2st::print_msg "Creating branch '${branch_name}'..."
 
     # Create branch from current HEAD and push to remote
-    if git checkout -b "$branch_name" && git push -u origin "$branch_name"; then
-        n2st::print_msg_done "Branch '$branch_name' created and pushed to remote"
+    if git checkout -b "${branch_name}" && git push -u origin "${branch_name}"; then
+        n2st::print_msg_done "Branch '${branch_name}' created and pushed to remote"
         # Switch back to original branch
         git checkout -
     else
-        n2st::print_msg_error "Failed to create branch '$branch_name'"
+        n2st::print_msg_error "Failed to create branch '${branch_name}'"
         return 1
     fi
 }
@@ -222,7 +231,7 @@ EOF
 
     if [[ "$dry_run" == "true" ]]; then
         n2st::print_msg "DRY RUN: Would configure ${branch_name} with:"
-        echo "$protection_config" | jq '.'
+        echo "${protection_config}" | jq '.'
         return 0
     fi
 
@@ -231,7 +240,7 @@ EOF
         --method PUT \
         --header "Accept: application/vnd.github+json" \
         "/repos/${REPO_OWNER:?err}/${REPO_NAME:?err}/branches/${branch_name}/protection" \
-        --input <(echo "$protection_config") > /dev/null; then
+        --input <(echo "${protection_config}") > /dev/null; then
         n2st::print_msg_done "Branch protection configured for: ${branch_name}"
     else
         n2st::print_msg_error "Failed to configure branch protection for: ${branch_name}"
@@ -251,16 +260,16 @@ function gbp::update_releaserc_json() {
     fi
 
     # Only update if using non-default release branch name
-    if [[ "$release_branch" == "${REPO_DEFAULT_BRANCH:-main}" ]]; then
+    if [[ "${release_branch}" == "${REPO_DEFAULT_BRANCH:-main}" ]]; then
         n2st::print_msg "Using default release branch name, no .releaserc.json update needed"
         return 0
     fi
 
     n2st::print_msg "Updating .releaserc.json with custom release branch name..."
 
-    if [[ "$dry_run" == "true" ]]; then
+    if [[ "${dry_run}" == "true" ]]; then
         n2st::print_msg "DRY RUN: Would update .releaserc.json:"
-        echo "  - Release branch: $release_branch"
+        echo "  - Release branch: ${release_branch}"
         return 0
     fi
 
@@ -269,12 +278,12 @@ function gbp::update_releaserc_json() {
 
     # Update the branches configuration using jq
     local updated_config
-    updated_config=$(jq --arg release_branch "$release_branch" '
+    updated_config=$(jq --arg release_branch "${release_branch}" '
         .branches[0] = $release_branch
     ' .releaserc.json)
 
     if [[ $? -eq 0 ]]; then
-        echo "$updated_config" > .releaserc.json
+        echo "${updated_config}" > .releaserc.json
         n2st::print_msg_done ".releaserc.json updated successfully"
         echo "Backup saved as .releaserc.json.backup"
     else
@@ -296,7 +305,7 @@ function gbp::update_semantic_release_yml() {
     fi
 
     # Only update if using non-default release branch name
-    if [[ "$release_branch" == "${REPO_DEFAULT_BRANCH:-main}" ]]; then
+    if [[ "${release_branch}" == "${REPO_DEFAULT_BRANCH:-main}" ]]; then
         n2st::print_msg "Using default release branch name, no semantic_release.yml update needed"
         return 0
     fi
@@ -305,7 +314,7 @@ function gbp::update_semantic_release_yml() {
 
     if [[ "$dry_run" == "true" ]]; then
         n2st::print_msg "DRY RUN: Would update .github/workflows/semantic_release.yml:"
-        echo "  - Release branch: $release_branch"
+        echo "  - Release branch: ${release_branch}"
         return 0
     fi
 
@@ -314,7 +323,7 @@ function gbp::update_semantic_release_yml() {
 
     # Update the branches configuration using sed
     local default_branch="${REPO_DEFAULT_BRANCH:-main}"
-    if sed -i.tmp "s/- $default_branch/- $release_branch/g" .github/workflows/semantic_release.yml; then
+    if sed -i.tmp "s/- $default_branch/- ${release_branch}/g" .github/workflows/semantic_release.yml; then
         rm -f .github/workflows/semantic_release.yml.tmp
         n2st::print_msg_done "semantic_release.yml updated successfully"
         echo "Backup saved as .github/workflows/semantic_release.yml.backup"
@@ -385,7 +394,7 @@ function gbp::main() {
     gbp::validate_prerequisites || return 1
 
     # Get repository information
-    gbp::get_repository_info
+    gbp::get_repository_info || return 1
     test -n "${REPO_OWNER:?err}" || n2st::print_msg_error_and_exit "Env variable REPO_OWNER need to be set and non-empty."
     test -n "${REPO_NAME:?err}" || n2st::print_msg_error_and_exit "Env variable REPO_NAME need to be set and non-empty."
     test -n "${REPO_DEFAULT_BRANCH:?err}" || n2st::print_msg_error_and_exit "Env variable REPO_DEFAULT_BRANCH need to be set and non-empty."
@@ -393,40 +402,35 @@ function gbp::main() {
     # Set release branch to repository default if not specified by user
     if [[ "$release_branch_specified" == "false" ]]; then
         release_branch="${REPO_DEFAULT_BRANCH:-main}"
-        n2st::print_msg "Using repository default branch as release branch: $release_branch"
+        n2st::print_msg "Using repository default branch as release branch: ${release_branch}"
     fi
-
-    # Update .releaserc.json if using non-default release branch name
-    gbp::update_releaserc_json "$release_branch" "$dry_run"
-
-    # Update semantic_release.yml if using non-default release branch name
-    gbp::update_semantic_release_yml "$release_branch" "$dry_run"
 
     # Configure branches
-    if [[ -n "$arbitrary_branch" ]]; then
+    if [[ -n "${arbitrary_branch}" ]]; then
         # Create branch if it doesn't exist
-        gbp::create_branch_if_not_exists "$arbitrary_branch" "$dry_run"
-        gbp::configure_branch_protection "$arbitrary_branch" "$dry_run"
+        gbp::create_branch_if_not_exists "${arbitrary_branch}" "${dry_run}" || return 1
+        gbp::configure_branch_protection "${arbitrary_branch}" "${dry_run}" || return 1
     else
         # Try to rename the default branch to the release branch if needed
-        gbp::rename_branch_if_needed "$release_branch" "$dry_run"
+        gbp::rename_branch_if_needed "${release_branch}" "${dry_run}" || return 1
+
+        # Update .releaserc.json if using non-default release branch name
+        gbp::update_releaserc_json "${release_branch}" "${dry_run}" || return 1
+
+        # Update semantic_release.yml if using non-default release branch name
+        gbp::update_semantic_release_yml "${release_branch}" "${dry_run}" || return 1
 
         # Configure release and dev branches
-        for branch in "$release_branch" "$pre_release_branch" "$dev_branch"; do
-            n2st::print_msg "Processing branch: $branch"
+        for branch in "${release_branch}" "${pre_release_branch}" "${dev_branch}"; do
+            n2st::print_msg "Processing branch: ${branch}"
             # Create branch if it doesn't exist
-            gbp::create_branch_if_not_exists "$branch" "$dry_run"
+            gbp::create_branch_if_not_exists "${branch}" "${dry_run}" || return 1
             # Configure protection
-            gbp::configure_branch_protection "$branch" "$dry_run"
+            gbp::configure_branch_protection "${branch}" "${dry_run}" || return 1
         done
 
-        # Set the default branch name
-        if [[ "$dry_run" == "false" ]]; then
-          gh repo edit --default-branch "$release_branch"
-        else
-          n2st::print_msg "DRY RUN: Would set repository default branch to '$release_branch'"
-        fi
     fi
+
 
     n2st::print_msg_done "Branch protection configuration completed"
     #n2st::print_formated_script_footer "$( basename $0)" "="
@@ -435,4 +439,5 @@ function gbp::main() {
 # Execute main function if script is run directly
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
     gbp::main "$@"
+    exit $?
 fi

--- a/initialize_norlab_project_template.bash
+++ b/initialize_norlab_project_template.bash
@@ -139,7 +139,7 @@ function tnp::install_norlab_project_template(){
 
       n2st::print_msg "Resetting ${MSG_DIMMED_FORMAT}CHANGELOG.md${MSG_END_FORMAT}"
       cd "${tmp_root}" || return 1
-      truncate --size=0 CHANGELOG.md
+      truncate -s 0 CHANGELOG.md
 
     else
       n2st::print_msg "Skipping Semantic-Release install"
@@ -307,7 +307,7 @@ function tnp::install_norlab_project_template(){
   }
 
   # ....Execute branch protection rule setup.......................................................
-  bash configure_github_branch_protection.bash "${gbp_args[@]}" || return 1
+  source configure_github_branch_protection.bash "${gbp_args[@]}" || return 1
 
 
   # ....Delayed N2ST deletion step.................................................................

--- a/initialize_norlab_project_template.bash
+++ b/initialize_norlab_project_template.bash
@@ -307,7 +307,8 @@ function tnp::install_norlab_project_template(){
   }
 
   # ....Execute branch protection rule setup.......................................................
-  source configure_github_branch_protection.bash "${gbp_args[@]}" || return 1
+  source configure_github_branch_protection.bash
+  gbp::main "${gbp_args[@]}" || return 1
 
 
   # ....Delayed N2ST deletion step.................................................................

--- a/tests/run_all_dryrun_and_tests_scripts.bash
+++ b/tests/run_all_dryrun_and_tests_scripts.bash
@@ -25,7 +25,6 @@ if [[ ${TEAMCITY_VERSION} ]]; then
         wget \
         ca-certificates \
         git \
-        git-credential-store \
         tree \
         zip gzip tar unzip \
         fontconfig \

--- a/tests/run_all_dryrun_and_tests_scripts.bash
+++ b/tests/run_all_dryrun_and_tests_scripts.bash
@@ -7,6 +7,11 @@
 #
 # =================================================================================================
 
+MSG_ERROR_FORMAT="\033[1;31m"
+MSG_DONE_FORMAT="\033[1;32m"
+MSG_END_FORMAT="\033[0m"
+
+# ....Setup........................................................................................
 if [[ ${TEAMCITY_VERSION} ]]; then
   # Assuming is run in a TC docker run wrapper
 
@@ -34,9 +39,27 @@ if [[ ${TEAMCITY_VERSION} ]]; then
   unset DEBIAN_FRONTEND
 fi
 
+# ....Begin........................................................................................
 tnp_root=$(git rev-parse --show-toplevel)
 
 bash "${tnp_root}/tests/tests_dryrun_and_tests_scripts/dryrun_configure_github_branch_protection.bash"
-EXIT_CODE=$?
+EXIT_CODE1=$?
 
-exit $EXIT_CODE
+bash "${tnp_root}/tests/tests_dryrun_and_tests_scripts/test_configure_github_branch_protection.bash"
+EXIT_CODE2=$?
+
+# ....Teardown.....................................................................................
+
+echo -e "Completed execution of:
+  - dryrun_configure_github_branch_protection.bash
+  - test_configure_github_branch_protection.bash
+"
+
+all_exit_code=$((EXIT_CODE1 + EXIT_CODE2))
+if [[ ${all_exit_code} == 0 ]]; then
+  echo -e "${MSG_DONE_FORMAT}[TNP done] ✓ All integration tests completed successfully!${MSG_END_FORMAT}"
+else
+  echo -e "${MSG_ERROR_FORMAT}[TNP error] ✗ Integration tests completed with failure!${MSG_END_FORMAT}"
+fi
+
+exit ${all_exit_code}

--- a/tests/run_all_dryrun_and_tests_scripts.bash
+++ b/tests/run_all_dryrun_and_tests_scripts.bash
@@ -25,6 +25,7 @@ if [[ ${TEAMCITY_VERSION} ]]; then
         wget \
         ca-certificates \
         git \
+        git-credential-store \
         tree \
         zip gzip tar unzip \
         fontconfig \
@@ -36,6 +37,7 @@ if [[ ${TEAMCITY_VERSION} ]]; then
   # This is required in our case since we deal with git submodule
   git config --global --add safe.directory "*"
 
+  git config --global credential.helper store
   git config --global user.name "RedLeader962"
   git config --global user.email "redleader962@gmail.com"
 

--- a/tests/run_all_dryrun_and_tests_scripts.bash
+++ b/tests/run_all_dryrun_and_tests_scripts.bash
@@ -39,6 +39,7 @@ if [[ ${TEAMCITY_VERSION} ]]; then
   git config --global credential.helper store
   git config --global user.name "RedLeader962"
   git config --global user.email "redleader962@gmail.com"
+  git config --global url.https://"${GITHUB_TOKEN}"@github.com/.insteadOf https://github.com/
 
   unset DEBIAN_FRONTEND
 fi

--- a/tests/run_all_dryrun_and_tests_scripts.bash
+++ b/tests/run_all_dryrun_and_tests_scripts.bash
@@ -36,6 +36,9 @@ if [[ ${TEAMCITY_VERSION} ]]; then
   # This is required in our case since we deal with git submodule
   git config --global --add safe.directory "*"
 
+  git config --global user.name "RedLeader962"
+  git config --global user.email "redleader962@gmail.com"
+
   unset DEBIAN_FRONTEND
 fi
 

--- a/tests/setup_integration_test.bash
+++ b/tests/setup_integration_test.bash
@@ -11,8 +11,6 @@
 #   read N2ST_PATH
 #
 # =================================================================================================
-pushd "$(pwd)" >/dev/null || exit 1
-
 
 function tnp::install_gh_cli_on_ci() {
   # Official doc: https://github.com/cli/cli/blob/trunk/docs/install_linux.md
@@ -93,8 +91,8 @@ EOF
 if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
   # This script is being run, ie: __name__="__main__"
 
-  cd "${N2ST_PATH:?'Variable not set'}" || exit 1
-  source "import_norlab_shell_script_tools_lib.bash" || exit 1
+  source "${N2ST_PATH:?'Variable not set'}/import_norlab_shell_script_tools_lib.bash" || exit 1
+
   n2st::print_formated_script_header "setup_integration_test.bash" "${MSG_LINE_CHAR_UTIL}"
   tnp::install_gh_cli_on_ci || exit 1
   tnp::install_jq_on_ci || exit 1
@@ -106,6 +104,3 @@ else
   echo -e "${tnp_error_prefix} This script must executed with bash! i.e.: $ bash $( basename "$0" )" 1>&2
   exit 1
 fi
-
-# ====Teardown=====================================================================================
-popd >/dev/null || exit 1

--- a/tests/setup_mock.bash
+++ b/tests/setup_mock.bash
@@ -13,7 +13,6 @@
 #   read N2ST_PATH
 #
 # =================================================================================================
-pushd "$(pwd)" >/dev/null || exit 1
 
 function tnp::setup_mock() {
   n2st::print_formated_script_header "setup_mock.bash" "${MSG_LINE_CHAR_UTIL}"
@@ -47,8 +46,7 @@ function tnp::setup_mock() {
 if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
   # This script is being run, ie: __name__="__main__"
 
-  cd "${N2ST_PATH:?'Variable not set'}" || exit 1
-  source "import_norlab_shell_script_tools_lib.bash" || exit 1
+  source "${N2ST_PATH:?'Variable not set'}/import_norlab_shell_script_tools_lib.bash" || exit 1
 
   tnp::setup_mock
 else
@@ -57,6 +55,3 @@ else
   echo -e "${tnp_error_prefix} This script must executed with bash! i.e.: $ bash $( basename "$0" )" 1>&2
   exit 1
 fi
-
-# ====Teardown=====================================================================================
-popd >/dev/null || exit 1

--- a/tests/teardown_integration_test.bash
+++ b/tests/teardown_integration_test.bash
@@ -15,10 +15,10 @@
 #   read N2ST_PATH
 #
 # =================================================================================================
-pushd "$(pwd)" >/dev/null || exit 1
 
 
 function tnp::reset_mock_repository_github_config() {
+  local non_default_branches=( "$@" )
   # Remove any branch protection rules that might have been added during testing
   # Note: This requires the repository to be accessible and the user to have admin rights
 
@@ -35,6 +35,14 @@ function tnp::reset_mock_repository_github_config() {
     if command -v gh &> /dev/null && gh auth status &> /dev/null 2>&1; then
       echo "Removing test branch protection rules..."
 
+      # Reverting repo release branch to original state
+      if ! git show-ref --verify --quiet "refs/heads/main" || \
+        ! git show-ref --verify --quiet "refs/remotes/origin/main"; then
+          git branch -m "main"
+          git push -u origin "main"
+          gh repo edit --default-branch "main"
+      fi
+
       # Get repository info
       local repo_info
       local repo_owner
@@ -45,14 +53,27 @@ function tnp::reset_mock_repository_github_config() {
 
       if [[ -n "$repo_owner" && -n "$repo_name" && "$repo_owner" != "null" && "$repo_name" != "null" ]]; then
         # Remove protection from main and dev branches if they exist
-        local branches_name=("main" "dev" "beta")
-        for branch in "${branches_name[@]}"; do
-          echo "Check branch: ${branch}"
-          if git show-ref --verify --quiet "refs/remotes/origin/${branch}" 2>/dev/null; then
-            echo "Removing protection from branch: ${branch}"
-            gh api --silent --method DELETE "/repos/$repo_owner/$repo_name/branches/${branch}/protection" 2>/dev/null || echo "No protection to remove for ${branch}"
+        local branches_name=("main" "dev" "beta" "${non_default_branches[@]}" )
+        for each_branch in "${branches_name[@]}"; do
+          echo "Check branch: ${each_branch}"
+          if git show-ref --verify --quiet "refs/remotes/origin/${each_branch}" 2>/dev/null; then
+            echo "Removing protection from branch: ${each_branch}"
+            gh api --silent --method DELETE "/repos/$repo_owner/$repo_name/branches/${each_branch}/protection" 2>/dev/null || echo "No protection to remove for ${each_branch}"
           else
-            echo "No branch ${branch}"
+            echo "No branch ${each_branch}"
+          fi
+        done
+
+        # Delete branches local and remote except default branch
+        local branches_name=("dev" "beta" "${non_default_branches[@]}" )
+        for each_branch in "${branches_name[@]}"; do
+          if git show-ref --verify --quiet "refs/heads/${each_branch}"; then
+            # Delete local branch if it exist
+            git branch -d "${each_branch}"
+          fi
+          if git show-ref --verify --quiet "refs/remotes/origin/${each_branch}"; then
+            # Delete remote branch if it exist
+            git push origin --delete "${each_branch}"
           fi
         done
       fi
@@ -81,10 +102,10 @@ function tnp::teardown_mock_semantic_release_files() {
 if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
   # This script is being run, ie: __name__="__main__"
 
-  cd "${N2ST_PATH:?'Variable not set'}" || exit 1
-  source "import_norlab_shell_script_tools_lib.bash" || exit 1
+  source "${N2ST_PATH:?'Variable not set'}/import_norlab_shell_script_tools_lib.bash" || exit 1
+
   n2st::print_formated_script_header "teardown_integration_test.bash" "${MSG_LINE_CHAR_UTIL}"
-  tnp::reset_mock_repository_github_config
+  tnp::reset_mock_repository_github_config "$@"
   tnp::teardown_mock_semantic_release_files
   n2st::print_formated_script_footer "teardown_integration_test.bash" "${MSG_LINE_CHAR_UTIL}"
 else
@@ -93,8 +114,5 @@ else
   echo -e "${tnp_error_prefix} This script must executed with bash! i.e.: $ bash $( basename "$0" )" 1>&2
   exit 1
 fi
-
-# ====Teardown=====================================================================================
-popd >/dev/null || exit 1
 
 

--- a/tests/teardown_mock.bash
+++ b/tests/teardown_mock.bash
@@ -13,7 +13,6 @@
 #   read N2ST_PATH
 #
 # =================================================================================================
-pushd "$(pwd)" >/dev/null || exit 1
 
 function tnp::teardown_mock() {
   n2st::print_formated_script_header "teardown_mock.bash" "${MSG_LINE_CHAR_UTIL}"
@@ -43,8 +42,7 @@ function tnp::teardown_mock() {
 if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
   # This script is being run, ie: __name__="__main__"
 
-  cd "${N2ST_PATH:?'Variable not set'}" || exit 1
-  source "import_norlab_shell_script_tools_lib.bash" || exit 1
+  source "${N2ST_PATH:?'Variable not set'}/import_norlab_shell_script_tools_lib.bash" || exit 1
 
   tnp::teardown_mock
 
@@ -54,8 +52,5 @@ else
   echo -e "${tnp_error_prefix} This script must executed with bash! i.e.: $ bash $( basename "$0" )" 1>&2
   exit 1
 fi
-
-# ====Teardown=====================================================================================
-popd >/dev/null || exit 1
 
 

--- a/tests/tests_bats/test_configure_github_branch_protection.bats
+++ b/tests/tests_bats/test_configure_github_branch_protection.bats
@@ -295,16 +295,6 @@ teardown() {
   assert_output --partial "Branch protection configured for: main"
 }
 
-@test "gbp::status_check_configuration should handle user input correctly" {
-  # Test CI configuration prompt with 'no' response
-  run bash -c "source ${BATS_DOCKER_WORKDIR}/${TESTED_FILE} && echo 'n' | gbp::status_check_configuration"
-  assert_success
-
-  # Test with CI checks input
-  run bash -c "source ${BATS_DOCKER_WORKDIR}/${TESTED_FILE} && echo -e 'y\rmock_ci_status/tests,mock_ci_status/build' | gbp::status_check_configuration"
-  assert_success
-  assert_output --partial "mock_ci_status/tests,mock_ci_status/build"
-}
 
 @test "gbp::show_help should display correct usage information" {
   run gbp::show_help
@@ -323,7 +313,6 @@ teardown() {
     REPO_NAME="test-repo"
     REPO_DEFAULT_BRANCH="main"
   }
-  function gbp::status_check_configuration() { return 0; }
   function gbp::create_branch_if_not_exists() { return 0; }
   function gbp::configure_branch_protection() { return 0; }
   function n2st::norlab_splash() { return 0; }
@@ -331,7 +320,7 @@ teardown() {
   function n2st::print_msg_done() { return 0; }
   function n2st::print_formated_script_footer() { return 0; }
   function n2st::print_msg() { return 0; }
-  export -f gbp::validate_prerequisites gbp::get_repository_info gbp::status_check_configuration
+  export -f gbp::validate_prerequisites gbp::get_repository_info
   export -f gbp::create_branch_if_not_exists gbp::configure_branch_protection
   export -f n2st::norlab_splash n2st::print_formated_script_header n2st::print_msg_done n2st::print_formated_script_footer n2st::print_msg
 
@@ -363,7 +352,6 @@ teardown() {
     REPO_NAME="test-repo"
     REPO_DEFAULT_BRANCH="main"
   }
-  function gbp::status_check_configuration() { return 0; }
   function gbp::update_releaserc_json() { return 0; }
   function gbp::update_semantic_release_yml() { return 0; }
   function gbp::create_branch_if_not_exists() { return 0; }
@@ -373,7 +361,7 @@ teardown() {
   function n2st::print_msg_done() { return 0; }
   function n2st::print_formated_script_footer() { return 0; }
   function n2st::print_msg() { return 0; }
-  export -f gbp::validate_prerequisites gbp::get_repository_info gbp::status_check_configuration
+  export -f gbp::validate_prerequisites gbp::get_repository_info
   export -f gbp::update_releaserc_json gbp::update_semantic_release_yml gbp::create_branch_if_not_exists gbp::configure_branch_protection
   export -f n2st::norlab_splash n2st::print_formated_script_header n2st::print_msg_done n2st::print_formated_script_footer n2st::print_msg
 
@@ -472,7 +460,6 @@ teardown() {
     REPO_NAME="test-repo"
     REPO_DEFAULT_BRANCH="main"
   }
-  function gbp::status_check_configuration() { return 0; }
   function gbp::update_releaserc_json() { return 0; }
   function gbp::update_semantic_release_yml() { return 0; }
   function gbp::create_branch_if_not_exists() { 
@@ -488,7 +475,7 @@ teardown() {
     echo "$*"
     return 0
   }
-  export -f gbp::validate_prerequisites gbp::get_repository_info gbp::status_check_configuration
+  export -f gbp::validate_prerequisites gbp::get_repository_info
   export -f gbp::update_releaserc_json gbp::update_semantic_release_yml gbp::create_branch_if_not_exists gbp::configure_branch_protection
   export -f n2st::norlab_splash n2st::print_formated_script_header n2st::print_msg_done n2st::print_formated_script_footer n2st::print_msg
 

--- a/tests/tests_bats/test_initialize_norlab_project_template.bats
+++ b/tests/tests_bats/test_initialize_norlab_project_template.bats
@@ -100,8 +100,12 @@ setup() {
   fi
 
   cat > "configure_github_branch_protection.bash" << 'EOF'
-# Note: 'configure_github_branch_protection.bash' is tested in 'test_configure_github_branch_protection.bats'
 echo "Mock 'configure_github_branch_protection.bash' script"
+# Note: 'configure_github_branch_protection.bash' is tested in 'test_configure_github_branch_protection.bats'
+
+function gbp::main() {
+  echo "Mock gbp::main called with args: $*"
+}
 EOF
 
 #  echo -e "\n› Pre test directory state" >&3 && pwd >&3 && tree -L 1 -a -hug >&3

--- a/tests/tests_bats/test_initialize_norlab_project_template.bats
+++ b/tests/tests_bats/test_initialize_norlab_project_template.bats
@@ -80,7 +80,7 @@ setup() {
 
     git clone  --branch "${TNP_TEAMCITY_PR_SOURCE}" "$TNP_GIT_REMOTE_URL"
 
-    cd "${TNP_GIT_NAME}"
+    cd "${TNP_GIT_NAME}" || exit 1
     echo -e "     [\033[1mN2ST bats container\033[0m] cwd=$(pwd)" # >&3
 
     git fetch --all
@@ -102,7 +102,6 @@ setup() {
   cat > "configure_github_branch_protection.bash" << 'EOF'
 # Note: 'configure_github_branch_protection.bash' is tested in 'test_configure_github_branch_protection.bats'
 echo "Mock 'configure_github_branch_protection.bash' script"
-exit 0
 EOF
 
 #  echo -e "\n› Pre test directory state" >&3 && pwd >&3 && tree -L 1 -a -hug >&3

--- a/tests/tests_dryrun_and_tests_scripts/dryrun_configure_github_branch_protection.bash
+++ b/tests/tests_dryrun_and_tests_scripts/dryrun_configure_github_branch_protection.bash
@@ -233,9 +233,9 @@ function tnp::main() {
     bash "${TNP_PATH}/tests/teardown_mock.bash"
 
     if [[ ${fct_exit_code} == 0 ]]; then
-      n2st::print_msg_done "${MSG_DONE_FORMAT}All integration tests completed successfully!${MSG_END_FORMAT}"
+      n2st::print_msg_done "${MSG_DONE_FORMAT}All dry-run tests completed successfully!${MSG_END_FORMAT}"
     else
-      n2st::print_msg_error "${MSG_ERROR_FORMAT}Integration tests completed with failure!${MSG_END_FORMAT}"
+      n2st::print_msg_error "${MSG_ERROR_FORMAT}Dry-run tests completed with failure!${MSG_END_FORMAT}"
     fi
     n2st::print_formated_script_footer "$(basename $0)" "="
     return ${fct_exit_code}

--- a/tests/tests_dryrun_and_tests_scripts/test_configure_github_branch_protection.bash
+++ b/tests/tests_dryrun_and_tests_scripts/test_configure_github_branch_protection.bash
@@ -1,0 +1,146 @@
+#!/bin/bash
+# =================================================================================================
+# Integration test for GitHub branch protection configuration
+# Note: This test requires a test repository and proper GitHub authentication
+# =================================================================================================
+
+set -e
+
+
+function tnp::test_both_branches_default() {
+    n2st::print_formated_script_header "Testing both branches configured with default name..." "/"
+
+    bash "${TNP_PATH:?err}/tests/setup_integration_test.bash"
+
+    cd "${TNP_MOCK_REPO_PATH}"
+
+    local exit_code
+    bash "${TNP_PATH}"/configure_github_branch_protection.bash
+    exit_code=$?
+
+    bash "${TNP_PATH}/tests/teardown_integration_test.bash"
+
+    if [[ $exit_code == 0 ]]; then
+        n2st::print_msg_done "✓ Both branches configured by default"
+        return 0
+    else
+        n2st::print_msg_error "✗ Not both branches configured by default"
+        return 1
+    fi
+}
+
+function tnp::test_branches_rename_release() {
+    n2st::print_formated_script_header "Testing branch renaming functionality (release)..." "/"
+
+    bash "${TNP_PATH:?err}/tests/setup_integration_test.bash"
+
+    cd "${TNP_MOCK_REPO_PATH}"
+
+    local exit_code
+    bash "${TNP_PATH}"/configure_github_branch_protection.bash --release-branch master
+    exit_code=$?
+
+    bash "${TNP_PATH}/tests/teardown_integration_test.bash" master
+
+    if [[ $exit_code == 0 ]]; then
+        n2st::print_msg_done "✓ Branch renaming functionality (release) works"
+        return 0
+    else
+        n2st::print_msg_error "✗ Branch renaming functionality (release) failed"
+        return 1
+    fi
+}
+
+function tnp::test_branches_rename_bleeding() {
+    n2st::print_formated_script_header "Testing branch renaming functionality (bleeding)..." "/"
+
+    bash "${TNP_PATH:?err}/tests/setup_integration_test.bash"
+
+    cd "${TNP_MOCK_REPO_PATH}"
+
+    local exit_code
+    bash "${TNP_PATH}"/configure_github_branch_protection.bash --dev-branch develop
+    exit_code=$?
+
+    bash "${TNP_PATH}/tests/teardown_integration_test.bash" develop
+
+    if [[ $exit_code == 0 ]]; then
+        n2st::print_msg_done "✓ Branch renaming functionality (bleeding) works"
+        return 0
+    else
+        n2st::print_msg_error "✗ Branch renaming functionality (bleeding) failed"
+        return 1
+    fi
+}
+
+function tnp::test_setup_arbitrary_branch() {
+    n2st::print_formated_script_header "Testing setup arbitrary branch..." "/"
+
+    bash "${TNP_PATH:?err}/tests/setup_integration_test.bash"
+
+    cd "${TNP_MOCK_REPO_PATH}"
+
+    local exit_code
+    bash "${TNP_PATH}"/configure_github_branch_protection.bash --branch feature1
+    exit_code=$?
+
+    bash "${TNP_PATH}/tests/teardown_integration_test.bash" feature1
+
+    if [[ $exit_code == 0 ]]; then
+        n2st::print_msg_done "✓ Setup arbitrary branch works"
+        return 0
+    else
+        n2st::print_msg_error "✗ Setup arbitrary branch failed"
+        return 1
+    fi
+}
+
+
+function tnp::main() {
+    echo "Starting GitHub branch protection integration tests..."
+
+    # ....Setup....................................................................................
+    TNP_PATH=$(git rev-parse --show-toplevel)
+    export TNP_PATH
+
+    # ....Load environment variables from file.......................................................
+    cd "${TNP_PATH}" || exit 1
+    set -o allexport
+    source .env.template-norlab-project.template
+    set +o allexport
+
+    source "${N2ST_PATH:?'Variable not set'}/import_norlab_shell_script_tools_lib.bash" || exit 1
+
+    n2st::norlab_splash "${PROJECT_GIT_NAME}" "${PROJECT_GIT_REMOTE_URL}"
+
+    n2st::print_formated_script_header "$(basename $0)" "="
+
+    export TNP_MOCK_REPO_PATH="${TNP_PATH:?err}/utilities/tmp/dockerized-norlab-project-mock-EMPTY"
+
+    bash "${TNP_PATH}/tests/setup_mock.bash"
+
+    # ....Begin....................................................................................
+    declare -i fct_exit_code=0
+
+    tnp::test_both_branches_default || ((fct_exit_code++))
+    tnp::test_branches_rename_release || ((fct_exit_code++))
+    tnp::test_branches_rename_bleeding || ((fct_exit_code++))
+    tnp::test_setup_arbitrary_branch || ((fct_exit_code++))
+
+    # ....Teardown.................................................................................
+    bash "${TNP_PATH}/tests/teardown_mock.bash"
+
+    if [[ ${fct_exit_code} == 0 ]]; then
+      n2st::print_msg_done "${MSG_DONE_FORMAT}All end-to-end tests completed successfully!${MSG_END_FORMAT}"
+    else
+      n2st::print_msg_error "${MSG_ERROR_FORMAT}End-to-end tests completed with failure!${MSG_END_FORMAT}"
+    fi
+    n2st::print_formated_script_footer "$(basename $0)" "="
+    return ${fct_exit_code}
+}
+
+# Execute main function if script is run directly
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    tnp::main "$@"
+    exit $?
+fi


### PR DESCRIPTION
# Description

## Summary of Changes:
- **Fix: Improve GitHub branch protection script validation** Enhanced validation logic in the branch protection script to ensure more robust error checking and better handling of edge cases.
- **Refactor: Remove interactive CI status check configuration in branch protection** Eliminated the interactive configuration for CI status checks in the branch protection system, likely moving to a more automated or configuration-file based approach.
- **Refactor: Enhance variable usage and streamline GitHub branch protection logic** Improved code quality by optimizing variable usage and simplifying the branch protection logic, making the code more maintainable and efficient.

These changes collectively improve the reliability and maintainability of the GitHub branch protection implementation.


# Checklist:

### Code related
- [x] I have made corresponding changes to the documentation (i.e.: function/class, script header, README.md)
- [x] I have commented hard-to-understand code 
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes (Check `tests/README.md` for local testing procedure) 
- [x] My commit messages follow the [conventional commits](https://www.conventionalcommits.org) specification. See `commit_msg_reference.md` in the repository root for details

### PR creation related 
- [x] My pull request `base ref` branch is set to the `dev` branch (the _build-system_ won't be triggered otherwise) 
- [x] My pull request branch is up-to-date with the `dev` branch (the _build-system_ will reject it otherwise)

 ## Note for repository admins
 ### Release PR related
- Only repository admins have the privilege to `push/merge` on the default branch (ie: `main`) and the `release` branch.
- Keep PR in `draft` mode until all the release reviewers are ready to push the release. 
- Once a PR from `release` -> `main` branch is created (not in draft mode), it triggers the _build-system_ test
- On merge to the `main` branch, it triggers the _semantic-release automation_
