### PR TITLE
feat: add support for private repositories owned by vaul-ulaval

### DIFF
--- a/initialize_norlab_project_template.bash
+++ b/initialize_norlab_project_template.bash
@@ -81,7 +81,7 @@ ${MSG_END_FORMAT}"
     #local repo_is_in_organization
     #repo_is_in_organization="$(gh repo view --json isInOrganization --jq '.isInOrganization')"
 
-    if [[ ${repo_is_private} == true ]] && [[ ${repo_owner} != "norlab-ulaval" ]]; then
+    if [[ ${repo_is_private} == true ]] && [[ ${repo_owner} != "norlab-ulaval" && ${repo_owner} != "vaul-ulaval" ]]; then
       n2st::print_msg_warning "${repo_name} is a private repository owned by ${repo_owner}.
 
   ${MSG_WARNING_FORMAT}Be advised, enabling branch protection rule on a private repository require a GitHub Pro plan${MSG_END_FORMAT}.
@@ -90,7 +90,7 @@ ${MSG_END_FORMAT}"
     Make repository visibility public ${MSG_DIMMED_FORMAT}-> (press 'P')${MSG_END_FORMAT}
     Skip branch configuration ${MSG_DIMMED_FORMAT}-> (press 'S')${MSG_END_FORMAT}
     Try it any way (I feel lucky) ${MSG_DIMMED_FORMAT}-> (press 'L')${MSG_END_FORMAT}
-    Exit, change repo ownership to norlab-ulaval and try again ${MSG_DIMMED_FORMAT}-> (press any other key)${MSG_END_FORMAT}
+    Exit, change repo ownership to norlab-ulaval (or vaul-ulaval) and try again ${MSG_DIMMED_FORMAT}-> (press any other key)${MSG_END_FORMAT}
 "
       unset user_input
       read -n 1 -r user_input
@@ -106,7 +106,7 @@ ${MSG_END_FORMAT}"
         n2st::print_msg "Understood, you feel lucky ☘️"
         :
       else
-        n2st::print_msg "Understood, see you back when repository ownership is switched to norlab-ulaval."
+        n2st::print_msg "Understood, see you back when repository ownership is switched to norlab-ulaval (or vaul-ulaval)."
         return 0
       fi
     fi


### PR DESCRIPTION
# Description

- Updated initialization script to allow handling repositories owned by both norlab-ulaval and vaul-ulaval as valid private repositories.
- Modified user prompts and warning messages to reflect new repository ownership criteria.
- Added test cases to validate script execution for vaul-ulaval private repository compatibility.

Issue TNP-51