### PR TITLE
Fix TeamCity image shield and update n2st to latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,7 @@ research-oriented best practice.**
 [//]: # ( ==== Badges ================================================ )
 [![semantic-release: conventional commits](https://img.shields.io/badge/semantic--release-conventional_commits-453032?logo=semantic-release)](https://github.com/semantic-release/semantic-release)
 <img alt="GitHub release (with filter)" src="https://img.shields.io/github/v/release/norlab-ulaval/template-norlab-project">
-
-[//]: # (NorLab teamcity)
-[//]: # (<a href="http://132.203.26.125:8111"><img src="https://img.shields.io/static/v1?label=JetBrains TeamCity&message=CI/CD&color=green?style=plastic&logo=teamcity" /></a>)
+<a href="http://132.203.26.125:8111"><img alt="Static Badge" src="https://img.shields.io/badge/JetBrains%20TeamCity-CI-green?style=plastic&logo=teamcity"></a>
 
 [//]: # (Dockerhub image badge)
 [//]: # (TODO: Change "norlabulaval/libpointmatcher" in both url to "your-dockerhub-domain/your-image-name")

--- a/README.norlab_template.md
+++ b/README.norlab_template.md
@@ -48,7 +48,7 @@ fermentum.
 
 [//]: # (NorLab teamcity)
 [//]: # (TODO: Un-comment the next line if your repository has run configuration enable on the norlab-teamcity-server)
-[//]: # (<a href="http://132.203.26.125:8111"><img src="https://img.shields.io/static/v1?label=JetBrains TeamCity&message=CI/CD&color=green?style=plastic&logo=teamcity" /></a>)
+[//]: # (<a href="http://132.203.26.125:8111"><img alt="Static Badge" src="https://img.shields.io/badge/JetBrains%20TeamCity-CI-green?style=plastic&logo=teamcity"></a>)
 
 [//]: # (Dockerhub image badge)
 [//]: # (TODO: Un-comment the next line if you have docker images on dockerhub)

--- a/README.vaul_template.md
+++ b/README.vaul_template.md
@@ -45,7 +45,7 @@ fermentum.
 
 [//]: # (NorLab teamcity)
 [//]: # (TODO: Un-comment the next line if your repository has run configuration enable on the norlab-teamcity-server)
-[//]: # (<a href="http://132.203.26.125:8111"><img src="https://img.shields.io/static/v1?label=JetBrains TeamCity&message=CI/CD&color=green?style=plastic&logo=teamcity" /></a>)
+[//]: # (<a href="http://132.203.26.125:8111"><img alt="Static Badge" src="https://img.shields.io/badge/JetBrains%20TeamCity-CI-green?style=plastic&logo=teamcity"></a>)
 
 [//]: # (Dockerhub image badge)
 [//]: # (TODO: Un-comment the next line if you have docker images on dockerhub)


### PR DESCRIPTION
# Description

This pull request fixes an issue with the TeamCity image shield not displaying correctly and updates n2st to the latest version, addressing the problem referenced in issue TNP-86.

# Commit Checklist:

## Code related
- [x] My commit messages follow the [conventional commits](https://www.conventionalcommits.org) specification. See `commit_msg_reference.md` in the repository root for details
- [x] All tests pass locally with my changes (Check `tests/README.md` for local testing procedure)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have made corresponding changes to the documentation (i.e.: function/class, script header, README.md)
- [ ] I have commented hard-to-understand code

## PR creation related
- [x] My pull request `base ref` branch is set to the `dev` branch (the _build-system_ won't be triggered otherwise)
- [x] My pull request branch is up-to-date with the `dev` branch (the _build-system_ will reject it otherwise)

# Note for repository admins
- Only repository admins have the privilege to `push/merge` on release, pre-release and bleeding edge branches (ie: `main`, `beta` and `dev`).
- On merge to a release or pre-release branch, it triggers the _semantic-release automation_